### PR TITLE
Populate home screen dynamically

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 
 class Home extends StatelessWidget {
-  const Home({
-    Key key,
-  }) : super(key: key);
+  
+  Map data = {};
 
   @override
   Widget build(BuildContext context) {
+     
+    data = ModalRoute.of(context).settings.arguments;
+
     return Scaffold(
       backgroundColor: Colors.teal[400],
       appBar: AppBar(
@@ -56,20 +58,20 @@ class Home extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
               Text(
-                  "1337",
+                  '${data['confirmed']}',
                   style: TextStyle(
                   fontSize: 20,
                 )),
               SizedBox(height: 15),
               Text(
-                "255",
+                '${data['recovered']}',
                 style: TextStyle(
                 // color: Colors.white,
                 fontSize: 20,
               )),
               SizedBox(height: 15),
               Text(
-                "40",
+                '${data['death']}',
                 style: TextStyle(
                 color: Colors.red[900],
                 fontSize: 20,

--- a/lib/loadingScreen.dart
+++ b/lib/loadingScreen.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:world_covid_update/services/getStatistics.dart';
@@ -10,11 +13,17 @@ class LoadingScreen extends StatefulWidget {
 class _LoadingScreenState extends State<LoadingScreen> {
   void fetchStatistics () async {
 
-    await getStatistics();
+    http.Response res =  await getStatistics();
+    Map data = jsonDecode(res.body);
+    int confirmed = data['data']['confirmed'];
+    int recovered = data['data']['recovered'];
+    int death = data['data']['deaths'];
+    print('I am a chosen one $data');
+
     Navigator.pushReplacementNamed(context, '/home', arguments: {
-      'confirned': 1337,
-      'recovered': 255,
-      'death': 40,
+      'confirmed': '$confirmed',
+      'recovered': '$recovered',
+      'death': '$death',
     });
   } 
 

--- a/lib/services/getStatistics.dart
+++ b/lib/services/getStatistics.dart
@@ -1,14 +1,15 @@
+import 'dart:convert';
+
 import 'package:http/http.dart' as http;
 
 Future<http.Response> getStatistics() async {
   try {
-    final result = await http.get(
+    http.Response result = await http.get(
       'https://covid-19-coronavirus-statistics.p.rapidapi.com/v1/total?country=Nigeria',
       headers: {
         "x-rapidapi-key": "3650547f88msha17e50374d780bep1c82ddjsn8baff41fae1e"
       },
     );
-    print('I am a chosen one ${result.body}');
     return result;
   } catch(e) {
     print('Could not get statistics, try again later. Error $e');


### PR DESCRIPTION
#### What does this PR do?
Populate home screen with result from covid-19 database

#### Task to be completed?
- [x] Refactor getStatistics method to return http response
- [x] Refactor loading srceen to pass along the return data from getStatistics method
- [x] Refactore home screen to display returned data

#### How should this be manually tested?
- run  `git branch populate-home-page-dynamically` to navigate to the branch
- make sure you have at least one device (live device or emulator) connected
- run `flutter run` to start the app
- on the connected device, it should show the current result of covid-19 statistics in Nigeria as of the time you are testing this branch

