### PR TITLE
Select country page

### DIFF
--- a/lib/getStatistics.dart
+++ b/lib/getStatistics.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:world_covid_update/services/getStatistics.dart';
+
+
+class Statistics extends StatefulWidget {
+  @override
+  _StatisticsState createState() => _StatisticsState();
+}
+
+class _StatisticsState extends State<Statistics> {
+  Map data = {};
+  void fetchStatistics() async {
+
+    http.Response res = await getStatistics(selectedCountry: data['selectedCountry']);
+    Map resultData = jsonDecode(res.body);
+    String country = resultData['response'][0]['country'];
+    int tested = resultData['response'][0]['tests']['total'];
+    int confirmed = resultData['response'][0]['cases']['total'];
+    int recovered = resultData['response'][0]['cases']['recovered'];
+    int critical = resultData['response'][0]['cases']['critical'];
+    int death = resultData['response'][0]['deaths']['total'];
+    
+    Navigator.pushReplacementNamed(context, '/home', arguments: {
+      'confirmed': '$confirmed',
+      'recovered': '$recovered',
+      'death': '$death',
+      'tested': '$tested',
+      'critical': '$critical',
+      'country': '$country',
+    });
+  } 
+  
+  @override
+  Widget build(BuildContext context) {
+    data = ModalRoute.of(context).settings.arguments;
+    fetchStatistics();
+    return Scaffold(
+      body: Center(child: Text('Please wait....'),),
+    );
+  }
+}

--- a/lib/loadContries.dart
+++ b/lib/loadContries.dart
@@ -21,7 +21,7 @@ class _LoadContriesState extends State<LoadContries> {
     }
 
     Navigator.pushReplacementNamed(context, '/select', arguments: {
-      'countries': '$countries'
+      'countries': countries,
     });
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:world_covid_update/home.dart';
 import 'package:world_covid_update/loadingScreen.dart';
 import 'package:world_covid_update/selectCountry.dart';
 import 'package:world_covid_update/loadContries.dart';
+import 'package:world_covid_update/getStatistics.dart';
 
 void main() => runApp(MaterialApp(
   initialRoute: '/',
@@ -11,5 +12,6 @@ void main() => runApp(MaterialApp(
     '/home': (context) => Home(),
     '/select': (context) => Country(),
     '/load-countries': (context) => LoadContries(),
+    '/get-statistics': (context) =>  Statistics(),
   }
 ));

--- a/lib/selectCountry.dart
+++ b/lib/selectCountry.dart
@@ -1,8 +1,5 @@
 import 'dart:convert';
-
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
-import 'package:world_covid_update/services/getCountries.dart';
 
 class Country extends StatefulWidget {
   
@@ -12,11 +9,15 @@ class Country extends StatefulWidget {
 
 class _CountryState extends State<Country> {
   Map countriesData = {};
+  List <String> countries = [];
+  String dropdownValue = 'Nigeria';
 
   @override
   Widget build(BuildContext context) {
     countriesData = ModalRoute.of(context).settings.arguments;
-    print('I am a chosen one ${countriesData['countries']}');
+    countries = countriesData['countries'];
+    countries.add('Nigeria');
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.teal,
@@ -24,7 +25,35 @@ class _CountryState extends State<Country> {
       ),
       body: Container(
         child: Center(
-          child: Text('I am a chosen one')
+          child: DropdownButton<String>(
+    value: dropdownValue,
+    icon: Icon(Icons.arrow_downward),
+    iconSize: 24,
+    elevation: 16,
+    style: TextStyle(
+      color: Colors.deepPurple
+    ),
+    underline: Container(
+      height: 2,
+      color: Colors.deepPurpleAccent,
+    ),
+    onChanged: (String newValue) {
+      setState(() {
+        dropdownValue = newValue;
+        Navigator.pushNamed(context, '/get-statistics', arguments: {
+          'selectedCountry': dropdownValue
+        },);
+      });
+    },
+    items: countries
+      .map<DropdownMenuItem<String>>((String value) {
+        return DropdownMenuItem<String>(
+          value: value,
+          child: Text(value),
+        );
+      })
+      .toList(),
+  ),
         ),
       ),
     );

--- a/lib/services/getStatistics.dart
+++ b/lib/services/getStatistics.dart
@@ -1,9 +1,9 @@
 import 'package:http/http.dart' as http;
 
-Future<http.Response> getStatistics() async {
+Future<http.Response> getStatistics({String selectedCountry = 'Nigeria'}) async {
   try {
     http.Response result = await http.get(
-      'https://covid-193.p.rapidapi.com/statistics?country=Aruba',
+      'https://covid-193.p.rapidapi.com/statistics?country=$selectedCountry',
       headers: {
         "x-rapidapi-key": "3650547f88msha17e50374d780bep1c82ddjsn8baff41fae1e"
       },


### PR DESCRIPTION
#### What does this PR do?
Enable users select countries of their choice and see the covid 19 update of that country

### Task to be completed?
- [x] Add getStatistic page to get selected country's statistical update
- [x] Refactor loadContries page to push countries in form of array to home page as against 
- [x] Pushing it as string
- [x] Add route to account for get statistic page
- [x] add Nigeria into countries array
- [x] refactor getStatistic method to include dynamic url

#### How should this be tested?
- clone the project and navigate to the current branch
- click on the floating icon button to load countries
- select country of your choice to see the covid-19 update of that country

